### PR TITLE
Improvements for Lecture 04 Notes

### DIFF
--- a/_posts/2025-09-15-lecture-04.md
+++ b/_posts/2025-09-15-lecture-04.md
@@ -19,6 +19,8 @@ authors:
 editors:
   - name: Ben Lengerich
     url: "https://lengerichlab.github.io/"
+  - name: Eva Song
+    url: NA
 
 abstract: >
   This lecture surveys single-layer neural networks with an emphasis on Rosenblatt’s perceptron. We unify notation for weights and bias, review activation choices, and relate them to learning dynamics. Geometrically, the model induces a hyperplane; the perceptron update rotates/shifts this boundary and converges on linearly separable data but cannot represent nonlinearly separable patterns such as XOR.
@@ -102,7 +104,7 @@ Before everything starts, we need to declare our terminology used here.
 For some **speical cases**, we may use some specifical terminology:
 
 + In perceptron (the classic Rosenblatt Perceptron): activation function = threshold function
-+ In linear regression: activation = identify function, so net input = output
++ In linear regression: activation = identity function(f(x)=x), so net input = output
 
 #### Mathematical Formulation
 

--- a/_posts/2025-09-15-lecture-04.md
+++ b/_posts/2025-09-15-lecture-04.md
@@ -104,7 +104,7 @@ Before everything starts, we need to declare our terminology used here.
 For some **speical cases**, we may use some specifical terminology:
 
 + In perceptron (the classic Rosenblatt Perceptron): activation function = threshold function
-+ In linear regression: activation = identity function(f(x)=x), so net input = output
++ In linear regression: activation = identity function ($f(x)=x$), so net input = output
 
 #### Mathematical Formulation
 


### PR DESCRIPTION
Link: https://github.com/NaCloudy/dgm-fall-2025/blob/main/_posts/2025-09-15-lecture-04.md
- Fix typo: the activation function for linear regression should be **identity function f(x)=x** instead of identify function.